### PR TITLE
Update docker registry repo

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,12 +45,13 @@ pipeline:
     image: plugins/docker
     insecure: true
     registry: registry.tola.io
-    repo: registry.tola.io/humanitec/walhall-sample-angular-app
+    repo: registry.tola.io/humanitec-walhall/walhall-sample-angular-app
     file: Dockerfile
     auto_tag: true
     secrets: [DOCKER_USERNAME, DOCKER_PASSWORD]
     when:
       event: [push, tag]
+      branch: [master]
       status: [success]
 
   notify:


### PR DESCRIPTION
## Purpose
We decided to move all the images to a new repo in docker registry, so we can separate them and use during the deployment in Walhall.