### PR TITLE
Fix drone notification removing branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -52,5 +52,4 @@ pipeline:
       from_secret: SLACK_WEBHOOK
     when:
       event: [push, tag]
-      branch: [master]
       status: [failure]


### PR DESCRIPTION
## Purpose
New Drone.io version doesn't work properly with branches in `when` step, so we should remove it to get notified when a build fails.